### PR TITLE
Add Gundaroo Common survey summary page

### DIFF
--- a/gundaroo-common-survey.html
+++ b/gundaroo-common-survey.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gundaroo Common Community Survey 2025</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="survey-page">
+    <header class="survey-hero">
+        <div class="survey-hero__inner">
+            <p class="survey-kicker">Community insights</p>
+            <h1>Gundaroo Common Community Survey 2025</h1>
+            <p class="survey-intro">
+                A visual summary of the Gundaroo community survey conducted in June 2025 to inform the future management of the Common.
+            </p>
+            <a class="survey-download" href="report_gundaroo_survey.pdf" download>
+                Download the full report (PDF)
+            </a>
+        </div>
+    </header>
+
+    <main class="survey-content">
+        <section class="survey-question" id="question-1">
+            <h2>1. How many people live in your household?</h2>
+            <p>
+                The survey received <strong>163 household responses</strong>, representing <strong>499 individuals</strong>&mdash;around <strong>40% of Gundaroo&rsquo;s population</strong> based on the 2021 ABS census.
+            </p>
+        </section>
+
+        <section class="survey-question" id="question-2">
+            <h2>2. Where does your household reside?</h2>
+            <p>
+                <strong>60% of responding households (98)</strong> live within the gazetted village boundary, with the remaining <strong>40%</strong> located in the surrounding district.
+            </p>
+        </section>
+
+        <section class="survey-question" id="question-3">
+            <h2>3. Before today, were you or your household aware of our village Common?</h2>
+            <p>
+                Awareness is universal: <strong>100% of respondents</strong> already knew about the Gundaroo Common before taking the survey.
+            </p>
+        </section>
+
+        <section class="survey-question" id="question-4">
+            <h2>4. Is anyone in your household a Commoner?</h2>
+            <p>
+                <strong>18% of households (30)</strong> reported that someone is on the roll of Commoners, while another <strong>15% (24 households)</strong> were unsure, pointing to an opportunity to improve communication about Commoner status.
+            </p>
+        </section>
+
+        <section class="survey-question" id="question-5">
+            <h2>5. In an average month, how often would you or someone from your household visit the Common?</h2>
+            <p>
+                The most common pattern was visiting <strong>2&ndash;3 times per month (30%)</strong>. A further <strong>38%</strong> of households visit at least weekly, and only <strong>7%</strong> said they never visit.
+            </p>
+            <figure class="survey-figure">
+                <img src="figures/f1_survey_e_colF_avg_month_barh.png" alt="Bar chart showing frequency of monthly visits to the Common">
+                <figcaption>Figure 1. Household visitation frequency each month.</figcaption>
+            </figure>
+        </section>
+
+        <section class="survey-question" id="question-6">
+            <h2>6. Which activities have you or your household engaged in at the Common?</h2>
+            <p>
+                Households make wide use of the Common. The leading activities were <strong>Walking (124 responses)</strong>, <strong>Nature appreciation (99)</strong>, and <strong>Dog walking (88)</strong>, alongside lower-frequency activities captured under &ldquo;Other&rdquo; responses.
+            </p>
+            <figure class="survey-figure">
+                <img src="figures/f2_survey_colG_barh_grouped_lt3_other.png" alt="Grouped bar chart showing activities undertaken at the Common">
+                <figcaption>Figure 2. Activities households participate in when visiting the Common.</figcaption>
+            </figure>
+        </section>
+
+        <section class="survey-question" id="question-7">
+            <h2>7. Select your household&rsquo;s primary or most frequent use of the Common.</h2>
+            <p>
+                When asked to choose a single primary use, <strong>Walking dominated with 64 households</strong>, reinforcing the Common&rsquo;s role as a recreational greenspace.
+            </p>
+            <figure class="survey-figure">
+                <img src="figures/f3_survey_g_colH_horizontal.png" alt="Horizontal bar chart showing households' primary use of the Common">
+                <figcaption>Figure 3. Primary household use of the Common.</figcaption>
+            </figure>
+        </section>
+
+        <section class="survey-question" id="question-8">
+            <h2>8. How would you rate the overall value of the Common to you or your household?</h2>
+            <p>
+                The Common is highly valued: <strong>69% of households</strong> gave it the maximum <strong>5 out of 5</strong>, and the overall average rating was <strong>4.4/5</strong>. Residents outside the village boundary value it almost as strongly as those inside (averages of 4.3 vs 4.6).
+            </p>
+            <figure class="survey-figure">
+                <img src="figures/f4_survey_h_colI_importance.png" alt="Stacked bar chart showing the value rating of the Common">
+                <figcaption>Figure 4. Overall value of the Common to households.</figcaption>
+            </figure>
+        </section>
+
+        <section class="survey-question" id="question-9">
+            <h2>9. If you value the Common, what are the main reasons?</h2>
+            <p>
+                The top reasons were <strong>Recreation and exercise (81%)</strong>, followed by <strong>Biodiversity (72%)</strong> and the <strong>Common&rsquo;s historical significance (56%)</strong>, illustrating a blend of practical use and heritage values.
+            </p>
+            <figure class="survey-figure">
+                <img src="figures/f5_survey_i_colJ_value_reasons_barh_grouped.png" alt="Grouped bar chart showing reasons households value the Common">
+                <figcaption>Figure 5. Reasons households value the Common.</figcaption>
+            </figure>
+        </section>
+
+        <section class="survey-question" id="question-10">
+            <h2>10. On a scale of 1&ndash;5, how important is the Common to your overall sense of community?</h2>
+            <p>
+                The sense of belonging is strong: the average rating was <strong>4.4/5</strong>, with <strong>61% of respondents</strong> selecting the maximum score of 5.
+            </p>
+            <figure class="survey-figure">
+                <img src="figures/f6_survey_j_colK_sense_community.png" alt="Stacked bar chart showing the importance of the Common to sense of community">
+                <figcaption>Figure 6. Importance of the Common to households&rsquo; sense of community.</figcaption>
+            </figure>
+        </section>
+
+        <section class="survey-question" id="question-11">
+            <h2>11. Would you consider donating money to support the management of the Common?</h2>
+            <p>
+                Support translates into action: <strong>82% of households (133)</strong> said they would consider donating to help manage the Common.
+            </p>
+        </section>
+
+        <section class="survey-question" id="question-12">
+            <h2>12. Additional comments or suggestions</h2>
+            <p>
+                <strong>67 households</strong> contributed comments. Thematic analysis highlighted eight recurring themes, led by <strong>General appreciation &amp; identity (37%)</strong>, along with <strong>Funding &amp; governance</strong>, <strong>Education &amp; community engagement</strong>, and <strong>Access, signage &amp; infrastructure</strong> (each 18%).
+            </p>
+            <p>
+                Explore the full feedback, data tables, and methodology in the downloadable PDF report.
+            </p>
+        </section>
+    </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -153,3 +153,133 @@ main {
   width: 10%;
   height: auto;
 }
+
+/* Survey page styles */
+.survey-page {
+  background-color: #f8f9fb;
+  color: #1f2933;
+  font-family: 'Roboto', sans-serif;
+}
+
+.survey-hero {
+  background: linear-gradient(135deg, #1f77b4 0%, #3a9ad9 100%);
+  color: #fff;
+  padding: 4rem 1.5rem 3rem;
+}
+
+.survey-hero__inner {
+  max-width: 820px;
+  margin: 0 auto;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.survey-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.survey-hero h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+.survey-intro {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin: 0 auto;
+  max-width: 680px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.survey-download {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.survey-download:hover,
+.survey-download:focus-visible {
+  background: rgba(255, 255, 255, 0.3);
+  transform: translateY(-2px);
+}
+
+.survey-content {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.survey-question {
+  background: #fff;
+  border-radius: 18px;
+  padding: 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.survey-question h2 {
+  font-size: clamp(1.4rem, 3.5vw, 1.8rem);
+  line-height: 1.3;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.survey-question p {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #334155;
+}
+
+.survey-question strong {
+  color: #0f172a;
+}
+
+.survey-figure {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.survey-figure img {
+  border-radius: 12px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.1);
+}
+
+.survey-figure figcaption {
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+@media (max-width: 600px) {
+  .survey-question {
+    padding: 1.5rem;
+  }
+
+  .survey-intro {
+    font-size: 1rem;
+  }
+
+  .survey-question p {
+    font-size: 0.95rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Gundaroo Common Community Survey page with question-by-question insights and supporting figures
- link to the downloadable PDF report and present survey highlights in a mobile-friendly single-column layout
- extend the shared stylesheet with survey-specific hero, card, and figure styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d13c6732f08332a2e5d546997640f1